### PR TITLE
Regenerate bindings for DuckDB 1.5.3; add GEOMETRY/VARIANT support + CI guard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-generated-api:
+    # Verify duckdb/_libduckdb.mojo was regenerated after any DuckDB version bump.
+    # The bindings are platform-independent, so this only needs to run once.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@v0.9.4
+        with:
+          pixi-version: v0.63.2
+          cache: true
+          environments: default
+
+      - name: Check generated bindings are up to date
+        run: |
+          source $HOME/.bash_profile
+          pixi run check-generated-api
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,16 +32,25 @@ jobs:
   build:
     strategy:
       matrix:
+        # mojo_target_flags pins a conservative codegen target on linux-64 to
+        # dodge a Mojo bug on GitHub's AMD EPYC 9V74 runners: host-CPU codegen
+        # emits AVX-512 that Azure has masked off, causing SIGILL. Every CI
+        # runner has AVX2, so x86-64-v3 is safe. Empty elsewhere (e.g. arm).
         include:
-          - { target: linux-64, os: ubuntu-24.04 }
+          - { target: linux-64, os: ubuntu-24.04, mojo_target_flags: "--target-cpu=x86-64-v3" }
           # TODO: re-enable once the aarch64 Int128 by-value ABI issue is fixed
           # (4 test_appender hugeint/uhugeint failures with garbage register/stack contents).
-          # - { target: linux-aarch64, os: ubuntu-22.04-arm }
-          - { target: osx-arm64, os: macos-15 }
+          # - { target: linux-aarch64, os: ubuntu-22.04-arm, mojo_target_flags: "" }
+          - { target: osx-arm64, os: macos-15, mojo_target_flags: "" }
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
+
+    # Consumed by scripts/run_tests.sh, the extension pixi tasks, and the
+    # example step below. Only set here (CI), so local builds stay native.
+    env:
+      MOJO_TARGET_FLAGS: ${{ matrix.mojo_target_flags }}
 
     defaults:
       run:
@@ -86,9 +95,5 @@ jobs:
         if: always()
         run: |
           source $HOME/.bash_profile
-          # See scripts/run_tests.sh for why linux-x86_64 pins a conservative CPU.
-          MOJO_TARGET=()
-          if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
-            MOJO_TARGET=(--target-cpu x86-64-v3)
-          fi
-          pixi run mojo run "${MOJO_TARGET[@]}" example.mojo
+          # $MOJO_TARGET_FLAGS is set at the job level (CI only); empty off-CI.
+          pixi run mojo run $MOJO_TARGET_FLAGS example.mojo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,10 +75,15 @@ jobs:
           restore-keys: |
             mojo-cache-v2-${{ matrix.target }}-
 
-      - name: Execute tests
+      - name: Run test suite
         env:
           DUCKDB_MOJO_FULL_TESTS: "1"
         run: |
           source $HOME/.bash_profile
-          pixi run mojo run example.mojo
           pixi run test
+
+      - name: Run example (smoke test, needs network)
+        if: always()
+        run: |
+          source $HOME/.bash_profile
+          pixi run mojo run example.mojo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.63.2
+          pixi-version: v0.69.0
           cache: true
           environments: default
 
@@ -58,9 +58,9 @@ jobs:
           swap-size-gb: 10
 
       - name: Setup pixi
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.63.2
+          pixi-version: v0.69.0
           cache: true
           environments: default
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,4 +86,9 @@ jobs:
         if: always()
         run: |
           source $HOME/.bash_profile
-          pixi run mojo run example.mojo
+          # See scripts/run_tests.sh for why linux-x86_64 pins a conservative CPU.
+          MOJO_TARGET=()
+          if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
+            MOJO_TARGET=(--target-cpu x86-64-v3)
+          fi
+          pixi run mojo run "${MOJO_TARGET[@]}" example.mojo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ pixi run test                 # Run all tests (library + extensions)
 pixi run test-library         # Run library tests only
 pixi run mojo run example.mojo  # Run example
 pixi run generate-api         # Regenerate C API bindings from DuckDB source
+pixi run check-generated-api  # Fail if _libduckdb.mojo is out of sync with DuckDB
 pixi build                    # Build conda package
 ```
 
@@ -51,7 +52,7 @@ pixi build                    # Build conda package
 ## Key Patterns
 
 - The `Connection` type is parameterized with `ApiLevel` (CLIENT, EXT_STABLE, EXT_UNSTABLE) to gate API access at compile time
-- `_libduckdb.mojo` is auto-generated - regenerate with `pixi run generate-api` after bumping DuckDB version
+- `_libduckdb.mojo` is auto-generated - regenerate with `pixi run generate-api` after bumping DuckDB version. CI runs `check-generated-api` (a dedicated job in `test.yml`) to fail the build if the committed bindings are stale, so a forgotten regeneration can't slip into main.
 - Extensions use the DuckDB Extension C API with stable/unstable split
 
 ## FFI Struct ABI Workaround

--- a/duckdb/_libduckdb.mojo
+++ b/duckdb/_libduckdb.mojo
@@ -101,6 +101,10 @@ comptime DUCKDB_TYPE_STRING_LITERAL = 37
 comptime DUCKDB_TYPE_INTEGER_LITERAL = 38
 # duckdb_time_ns (nanoseconds)
 comptime DUCKDB_TYPE_TIME_NS = 39
+# GEOMETRY type, WKB blob
+comptime DUCKDB_TYPE_GEOMETRY = 40
+# VARIANT type
+comptime DUCKDB_TYPE_VARIANT = 41
 
 #! An enum over the returned state of different functions.
 comptime duckdb_state = Int32
@@ -1095,7 +1099,7 @@ struct duckdb_ext_api_v1:
 struct duckdb_ext_api_v1_unstable:
     """DuckDB Extension C API function pointer table (duckdb_ext_api_v1_unstable).
 
-    Contains 545 function pointers.
+    Contains 546 function pointers.
     """
 
     # --- v1.2.0 ---
@@ -1612,6 +1616,9 @@ struct duckdb_ext_api_v1_unstable:
     var duckdb_file_handle_tell: def(duckdb_file_handle) thin abi("C") -> Int64
     var duckdb_file_handle_sync: def(duckdb_file_handle) thin abi("C") -> duckdb_state
     var duckdb_file_handle_size: def(duckdb_file_handle) thin abi("C") -> Int64
+
+    # --- unstable_new_geo_functions ---
+    var duckdb_geometry_type_get_crs: def(duckdb_logical_type) thin abi("C") -> UnsafePointer[c_char, MutExternalOrigin]
 
     # --- unstable_new_logger_functions ---
     var duckdb_create_log_storage: def() thin abi("C") -> duckdb_log_storage
@@ -2212,6 +2219,7 @@ struct LibDuckDB(Movable):
     var _duckdb_log_storage_set_extra_data: _duckdb_log_storage_set_extra_data.fn_type
     var _duckdb_log_storage_set_name: _duckdb_log_storage_set_name.fn_type
     var _duckdb_register_log_storage: _duckdb_register_log_storage.fn_type
+    var _duckdb_geometry_type_get_crs: _duckdb_geometry_type_get_crs.fn_type
 
     def __init__(out self):
         """Initialize LibDuckDB by loading functions via dlopen/dlsym.
@@ -2717,6 +2725,7 @@ struct LibDuckDB(Movable):
             self._duckdb_log_storage_set_extra_data = _duckdb_log_storage_set_extra_data.load()
             self._duckdb_log_storage_set_name = _duckdb_log_storage_set_name.load()
             self._duckdb_register_log_storage = _duckdb_register_log_storage.load()
+            self._duckdb_geometry_type_get_crs = _duckdb_geometry_type_get_crs.load()
         except e:
             abort(String(e))
 
@@ -3227,6 +3236,7 @@ struct LibDuckDB(Movable):
             self._duckdb_log_storage_set_extra_data = _duckdb_log_storage_set_extra_data.load()
             self._duckdb_log_storage_set_name = _duckdb_log_storage_set_name.load()
             self._duckdb_register_log_storage = _duckdb_register_log_storage.load()
+            self._duckdb_geometry_type_get_crs = _duckdb_geometry_type_get_crs.load()
         except e:
             abort(String(e))
 
@@ -3734,6 +3744,7 @@ struct LibDuckDB(Movable):
         self._duckdb_log_storage_set_extra_data = api[].duckdb_log_storage_set_extra_data
         self._duckdb_log_storage_set_name = api[].duckdb_log_storage_set_name
         self._duckdb_register_log_storage = api[].duckdb_register_log_storage
+        self._duckdb_geometry_type_get_crs = api[].duckdb_geometry_type_get_crs
 
     def __init__(out self, *, deinit take: Self):
         self._duckdb_create_instance_cache = take._duckdb_create_instance_cache
@@ -4235,6 +4246,7 @@ struct LibDuckDB(Movable):
         self._duckdb_log_storage_set_extra_data = take._duckdb_log_storage_set_extra_data
         self._duckdb_log_storage_set_name = take._duckdb_log_storage_set_name
         self._duckdb_register_log_storage = take._duckdb_register_log_storage
+        self._duckdb_geometry_type_get_crs = take._duckdb_geometry_type_get_crs
 
     # ===--------------------------------------------------------------------===#
     # Functions
@@ -9678,6 +9690,21 @@ struct LibDuckDB(Movable):
         return self._duckdb_register_log_storage(database, log_storage)
 
 
+    # ===--------------------------------------------------------------------===#
+    # Geometry Helpers
+    # ===--------------------------------------------------------------------===#
+
+    def duckdb_geometry_type_get_crs(
+        self,
+        type_: duckdb_logical_type,
+    ) -> UnsafePointer[c_char, MutExternalOrigin]:
+        """
+        Gets the CRS (Coordinate Reference System) of a GEOMETRY type.
+        Result must be freed with `duckdb_free`.
+        """
+        return self._duckdb_geometry_type_get_crs(type_)
+
+
 
 # ===--------------------------------------------------------------------===#
 # Open Connect
@@ -12366,5 +12393,15 @@ comptime _duckdb_log_storage_set_name = _dylib_function["duckdb_log_storage_set_
 # [ext_api: unstable_new_logger_functions]
 comptime _duckdb_register_log_storage = _dylib_function["duckdb_register_log_storage",
     def(duckdb_database, duckdb_log_storage) thin abi("C") -> duckdb_state
+]
+
+
+# ===--------------------------------------------------------------------===#
+# Geometry Helpers
+# ===--------------------------------------------------------------------===#
+
+# [ext_api: unstable_new_geo_functions]
+comptime _duckdb_geometry_type_get_crs = _dylib_function["duckdb_geometry_type_get_crs",
+    def(duckdb_logical_type) thin abi("C") -> UnsafePointer[c_char, MutExternalOrigin]
 ]
 

--- a/duckdb/duckdb_type.mojo
+++ b/duckdb/duckdb_type.mojo
@@ -89,6 +89,19 @@ struct DuckDBType(
     """DuckDB type: TIMESTAMP_TZ."""
     comptime time_ns = DuckDBType(DUCKDB_TYPE_TIME_NS)
     """DuckDB type: TIME_NS, time in nanoseconds."""
+    comptime geometry = DuckDBType(DUCKDB_TYPE_GEOMETRY)
+    """DuckDB type: GEOMETRY (DuckDB 1.5+), stored as a WKB blob.
+
+    The C API exposes `duckdb_geometry_type_get_crs` for reading the
+    Coordinate Reference System; see `LogicalType.geometry_type_crs`.
+    """
+    comptime variant = DuckDBType(DUCKDB_TYPE_VARIANT)
+    """DuckDB type: VARIANT (DuckDB 1.5+), a self-describing nested value.
+
+    Physically a STRUCT; the C API has no dedicated VARIANT helpers yet, so
+    there is no native value decoding. Read values by casting to VARCHAR/JSON
+    in SQL (e.g. `SELECT my_variant::VARCHAR`).
+    """
 
     # def __init__(out self, value: LogicalType):
     #     """Create a DuckDBType from a LogicalType."""
@@ -222,6 +235,10 @@ struct DuckDBType(
             return writer.write("timestamp_tz")
         if self == DuckDBType.time_ns:
             return writer.write("time_ns")
+        if self == DuckDBType.geometry:
+            return writer.write("geometry")
+        if self == DuckDBType.variant:
+            return writer.write("variant")
         return writer.write("<<unknown>>")
 
     def __eq__(self, rhs: DuckDBType) -> Bool:

--- a/duckdb/logical_type.mojo
+++ b/duckdb/logical_type.mojo
@@ -1,6 +1,6 @@
 from duckdb._libduckdb import *
 from duckdb.database import _null_ptr
-from std.collections import List
+from std.collections import List, Optional
 
 
 
@@ -195,6 +195,27 @@ struct LogicalType[is_owned: Bool, origin: ImmutOrigin](ImplicitlyCopyable & Mov
         return LogicalType[is_owned=True, origin=MutExternalOrigin](
             libduckdb.duckdb_struct_type_child_type(self._logical_type, index)
         )
+
+    def geometry_type_crs(self) -> Optional[String]:
+        """Retrieves the CRS (Coordinate Reference System) of a GEOMETRY type.
+
+        Returns `None` if this type is not a GEOMETRY or has no CRS set.
+        Requires DuckDB 1.5+ (`duckdb_geometry_type_get_crs`).
+
+        * returns: The CRS string, or `None`.
+        """
+        ref libduckdb = DuckDB().libduckdb()
+        # A NULL char* (not a GEOMETRY / no CRS) converts to a `None` Optional
+        # via the pointer null-niche encoding.
+        var c_str: Optional[UnsafePointer[c_char, MutExternalOrigin]] = (
+            libduckdb.duckdb_geometry_type_get_crs(self._logical_type)
+        )
+        if not c_str:
+            return None
+        var ptr = c_str.value()
+        var result = String(unsafe_from_utf8_ptr=ptr)
+        libduckdb.duckdb_free(ptr.bitcast[NoneType]())
+        return result
 
     def __eq__(self, other: Self) -> Bool:
         if self.get_type_id() != other.get_type_id():

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,24 +38,18 @@ generate-api = { cmd = "python3 scripts/generate_mojo_api.py --duckdb-dir .duckd
 # (regenerates first via generate-api, then checks for an unexpected diff).
 check-generated-api = { cmd = "bash scripts/check_generated_api.sh", depends-on = ["generate-api"] }
 
-# Demo extension
-build-demo-extension = { cmd = "mkdir -p demo-extension/build && mojo build demo-extension/src/demo_mojo_extension.mojo --emit shared-lib -o demo-extension/build/demo_mojo.duckdb_extension && python3 scripts/append_extension_metadata.py demo-extension/build/demo_mojo.duckdb_extension", depends-on = ["build"] }
+# Demo extension.
+# The mojo build/run calls are wrapped in `bash -c` so $MOJO_TARGET_FLAGS (set
+# ONLY in CI, see .github/workflows/test.yml) is applied as a codegen target
+# override on the affected runners. Unset locally → expands to nothing → native.
+build-demo-extension = { cmd = "bash -c 'mkdir -p demo-extension/build && mojo build $MOJO_TARGET_FLAGS demo-extension/src/demo_mojo_extension.mojo --emit shared-lib -o demo-extension/build/demo_mojo.duckdb_extension && python3 scripts/append_extension_metadata.py demo-extension/build/demo_mojo.duckdb_extension'", depends-on = ["build"] }
 test-demo-extension = { cmd = "duckdb -unsigned -c \"LOAD 'demo-extension/build/demo_mojo.duckdb_extension'; SELECT mojo_add_numbers(40, 2) AS result;\"", depends-on = ["build-demo-extension"] }
 
 # Test extension
-build-test-extension = { cmd = "mkdir -p test-extension/build && mojo build test-extension/src/test_mojo_extension.mojo --emit shared-lib -o test-extension/build/mojo.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo.duckdb_extension && mojo build test-extension/src/test_bad_api_extension.mojo --emit shared-lib -o test-extension/build/bad_api.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/bad_api.duckdb_extension && mojo build test-extension/src/test_mojo_unstable_extension.mojo --emit shared-lib -o test-extension/build/mojo_unstable.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo_unstable.duckdb_extension --abi-type C_STRUCT_UNSTABLE", depends-on = ["build"] }
-test-extension = { cmd = "mojo run test-extension/test_extension.mojo", depends-on = ["build-test-extension"] }
+build-test-extension = { cmd = "bash -c 'mkdir -p test-extension/build && mojo build $MOJO_TARGET_FLAGS test-extension/src/test_mojo_extension.mojo --emit shared-lib -o test-extension/build/mojo.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo.duckdb_extension && mojo build $MOJO_TARGET_FLAGS test-extension/src/test_bad_api_extension.mojo --emit shared-lib -o test-extension/build/bad_api.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/bad_api.duckdb_extension && mojo build $MOJO_TARGET_FLAGS test-extension/src/test_mojo_unstable_extension.mojo --emit shared-lib -o test-extension/build/mojo_unstable.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo_unstable.duckdb_extension --abi-type C_STRUCT_UNSTABLE'", depends-on = ["build"] }
+test-extension = { cmd = "bash -c 'mojo run $MOJO_TARGET_FLAGS test-extension/test_extension.mojo'", depends-on = ["build-test-extension"] }
 
 test = {depends-on = ["test-library", "test-demo-extension", "test-extension"]}
-
-# linux-64 overrides: pin a conservative target CPU for the extension builds.
-# Mirrors the base tasks above with `--target-cpu=x86-64-v3` added to each mojo
-# invocation — see scripts/run_tests.sh for why (Mojo emits AVX-512 on GitHub's
-# AMD EPYC 9V74 runners where Azure masks it, causing SIGILL). Keep in sync.
-[target.linux-64.tasks]
-build-demo-extension = { cmd = "mkdir -p demo-extension/build && mojo build --target-cpu=x86-64-v3 demo-extension/src/demo_mojo_extension.mojo --emit shared-lib -o demo-extension/build/demo_mojo.duckdb_extension && python3 scripts/append_extension_metadata.py demo-extension/build/demo_mojo.duckdb_extension", depends-on = ["build"] }
-build-test-extension = { cmd = "mkdir -p test-extension/build && mojo build --target-cpu=x86-64-v3 test-extension/src/test_mojo_extension.mojo --emit shared-lib -o test-extension/build/mojo.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo.duckdb_extension && mojo build --target-cpu=x86-64-v3 test-extension/src/test_bad_api_extension.mojo --emit shared-lib -o test-extension/build/bad_api.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/bad_api.duckdb_extension && mojo build --target-cpu=x86-64-v3 test-extension/src/test_mojo_unstable_extension.mojo --emit shared-lib -o test-extension/build/mojo_unstable.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo_unstable.duckdb_extension --abi-type C_STRUCT_UNSTABLE", depends-on = ["build"] }
-test-extension = { cmd = "mojo run --target-cpu=x86-64-v3 test-extension/test_extension.mojo", depends-on = ["build-test-extension"] }
 
 # for local development
 [dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,6 +48,15 @@ test-extension = { cmd = "mojo run test-extension/test_extension.mojo", depends-
 
 test = {depends-on = ["test-library", "test-demo-extension", "test-extension"]}
 
+# linux-64 overrides: pin a conservative target CPU for the extension builds.
+# Mirrors the base tasks above with `--target-cpu=x86-64-v3` added to each mojo
+# invocation — see scripts/run_tests.sh for why (Mojo emits AVX-512 on GitHub's
+# AMD EPYC 9V74 runners where Azure masks it, causing SIGILL). Keep in sync.
+[target.linux-64.tasks]
+build-demo-extension = { cmd = "mkdir -p demo-extension/build && mojo build --target-cpu=x86-64-v3 demo-extension/src/demo_mojo_extension.mojo --emit shared-lib -o demo-extension/build/demo_mojo.duckdb_extension && python3 scripts/append_extension_metadata.py demo-extension/build/demo_mojo.duckdb_extension", depends-on = ["build"] }
+build-test-extension = { cmd = "mkdir -p test-extension/build && mojo build --target-cpu=x86-64-v3 test-extension/src/test_mojo_extension.mojo --emit shared-lib -o test-extension/build/mojo.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo.duckdb_extension && mojo build --target-cpu=x86-64-v3 test-extension/src/test_bad_api_extension.mojo --emit shared-lib -o test-extension/build/bad_api.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/bad_api.duckdb_extension && mojo build --target-cpu=x86-64-v3 test-extension/src/test_mojo_unstable_extension.mojo --emit shared-lib -o test-extension/build/mojo_unstable.duckdb_extension && python3 scripts/append_extension_metadata.py test-extension/build/mojo_unstable.duckdb_extension --abi-type C_STRUCT_UNSTABLE", depends-on = ["build"] }
+test-extension = { cmd = "mojo run --target-cpu=x86-64-v3 test-extension/test_extension.mojo", depends-on = ["build-test-extension"] }
+
 # for local development
 [dependencies]
 libduckdb-devel = "=1.5.3"

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,6 +34,9 @@ build = "pixi run mojo package duckdb -o duckdb.mojopkg"
 test-library = { cmd = "bash scripts/run_tests.sh", depends-on = ["build"] }
 clone-duckdb = "sh scripts/clone_duckdb.sh"
 generate-api = { cmd = "python3 scripts/generate_mojo_api.py --duckdb-dir .duckdb-src --output duckdb/_libduckdb.mojo", depends-on = ["clone-duckdb"] }
+# Fails if duckdb/_libduckdb.mojo is out of sync with the DuckDB version
+# (regenerates first via generate-api, then checks for an unexpected diff).
+check-generated-api = { cmd = "bash scripts/check_generated_api.sh", depends-on = ["generate-api"] }
 
 # Demo extension
 build-demo-extension = { cmd = "mkdir -p demo-extension/build && mojo build demo-extension/src/demo_mojo_extension.mojo --emit shared-lib -o demo-extension/build/demo_mojo.duckdb_extension && python3 scripts/append_extension_metadata.py demo-extension/build/demo_mojo.duckdb_extension", depends-on = ["build"] }

--- a/scripts/check_generated_api.sh
+++ b/scripts/check_generated_api.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Verify that duckdb/_libduckdb.mojo is in sync with the DuckDB version.
+#
+# The bindings are generated from the DuckDB source (see scripts/generate_mojo_api.py).
+# This guards against forgetting to regenerate them after a DuckDB version bump.
+#
+# Run via `pixi run check-generated-api`, which regenerates the bindings (against
+# the version matching the installed `duckdb`) as a dependency before this script
+# runs. Here we only check whether that regeneration changed the committed file.
+set -e
+
+if git diff --quiet -- duckdb/_libduckdb.mojo; then
+    echo "duckdb/_libduckdb.mojo is up to date with the DuckDB source."
+    exit 0
+fi
+
+echo "ERROR: duckdb/_libduckdb.mojo is out of date with the DuckDB source."
+echo "Regenerate and commit it:"
+echo
+echo "    pixi run generate-api"
+echo
+echo "Diff (committed vs. freshly generated):"
+git --no-pager diff -- duckdb/_libduckdb.mojo
+exit 1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,15 +3,11 @@
 # The mojopkg must exist in CWD before this script runs.
 set -e
 
-# Workaround for a Mojo toolchain bug on GitHub's AMD EPYC 9V74 runners:
-# Mojo's host-CPU codegen detects znver4 and emits AVX-512 instructions, but
-# Azure masks AVX-512 on those VMs (avx512f absent in /proc/cpuinfo), so the
-# emitted code hits SIGILL. Pin a conservative x86-64 baseline — every CI
-# runner has AVX2, so x86-64-v3 is safe and AVX-512-free.
-MOJO_TARGET=()
-if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
-    MOJO_TARGET=(--target-cpu x86-64-v3)
-fi
+# Optional Mojo codegen target override. Set ONLY in CI (see
+# .github/workflows/test.yml) to work around a Mojo bug on GitHub's AMD EPYC
+# 9V74 runners, where host-CPU codegen emits AVX-512 that Azure has masked,
+# causing SIGILL. Unset locally → no override, so local builds stay native.
+read -ra MOJO_TARGET <<< "${MOJO_TARGET_FLAGS:-}"
 
 if [ ! -f "./duckdb.mojopkg" ]; then
     echo "ERROR: duckdb.mojopkg not found in CWD. Run 'pixi run build' first."

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,6 +3,16 @@
 # The mojopkg must exist in CWD before this script runs.
 set -e
 
+# Workaround for a Mojo toolchain bug on GitHub's AMD EPYC 9V74 runners:
+# Mojo's host-CPU codegen detects znver4 and emits AVX-512 instructions, but
+# Azure masks AVX-512 on those VMs (avx512f absent in /proc/cpuinfo), so the
+# emitted code hits SIGILL. Pin a conservative x86-64 baseline — every CI
+# runner has AVX2, so x86-64-v3 is safe and AVX-512-free.
+MOJO_TARGET=()
+if [[ "$(uname -s)" == "Linux" && "$(uname -m)" == "x86_64" ]]; then
+    MOJO_TARGET=(--target-cpu x86-64-v3)
+fi
+
 if [ ! -f "./duckdb.mojopkg" ]; then
     echo "ERROR: duckdb.mojopkg not found in CWD. Run 'pixi run build' first."
     exit 1
@@ -53,7 +63,7 @@ GENERIC_TESTS=(
 
 for f in "${TESTS[@]}"; do
     echo "--- Running: $f ---"
-    mojo run "$f"
+    mojo run "${MOJO_TARGET[@]}" "$f"
 done
 
 if [[ "${CI:-}" == "true" && -z "${DUCKDB_MOJO_FULL_TESTS:-}" && "$(uname)" != "Linux" ]]; then
@@ -61,6 +71,6 @@ if [[ "${CI:-}" == "true" && -z "${DUCKDB_MOJO_FULL_TESTS:-}" && "$(uname)" != "
 else
     for f in "${GENERIC_TESTS[@]}"; do
         echo "--- Running (-j 2): $f ---"
-        mojo run -j 2 "$f"
+        mojo run -j 2 "${MOJO_TARGET[@]}" "$f"
     done
 fi

--- a/test/test_duckdb_type.mojo
+++ b/test/test_duckdb_type.mojo
@@ -1,6 +1,7 @@
 """Tests for duckdb_type conversions."""
 
 from duckdb.duckdb_type import (
+    DuckDBType,
     Bit,
     Date,
     Time,
@@ -542,6 +543,31 @@ def test_timestamp_epoch() raises:
     assert_equal(d.day(), Int8(1))
     var t = ts.time()
     assert_equal(t.hour(), Int8(0))
+
+
+# ─── DuckDBType enum ──────────────────────────────────────────────
+
+
+def test_variant_type_str() raises:
+    """DuckDBType.variant stringifies to "variant" (DuckDB 1.5+)."""
+    assert_equal(String(DuckDBType.variant), "variant")
+
+
+def test_variant_type_distinct() raises:
+    """DuckDBType.variant is distinct from the physically-similar struct."""
+    assert_true(DuckDBType.variant != DuckDBType.struct_t)
+    assert_true(DuckDBType.variant == DuckDBType.variant)
+
+
+def test_geometry_type_str() raises:
+    """DuckDBType.geometry stringifies to "geometry" (DuckDB 1.5+)."""
+    assert_equal(String(DuckDBType.geometry), "geometry")
+
+
+def test_geometry_type_distinct() raises:
+    """DuckDBType.geometry is distinct from blob (its WKB physical form)."""
+    assert_true(DuckDBType.geometry != DuckDBType.blob)
+    assert_true(DuckDBType.geometry != DuckDBType.variant)
 
 
 # ─── run_suite ────────────────────────────────────────────────────

--- a/test/test_logical_type.mojo
+++ b/test/test_logical_type.mojo
@@ -18,9 +18,41 @@ def test_decimal_type() raises:
 
 def test_enum_type() raises:
     var names: List[String] = ["One", "Two", "Three"]
-    
+
     var t = enum_type(names)
     assert_equal(t.get_type_id(), DuckDBType.enum)
+
+def test_variant_type_id() raises:
+    """A VARIANT column reports DuckDBType.variant (DuckDB 1.5+)."""
+    var con = DuckDB.connect(":memory:")
+    var result = con.execute("SELECT CAST('{\"a\": 1}' AS VARIANT) AS v")
+    assert_equal(result.column_type(0).get_type_id(), DuckDBType.variant)
+
+def test_geometry_type_id() raises:
+    """A GEOMETRY column reports DuckDBType.geometry (DuckDB 1.5+)."""
+    var con = DuckDB.connect(":memory:")
+    var result = con.execute("SELECT CAST('POINT(0 1)' AS GEOMETRY) AS g")
+    assert_equal(result.column_type(0).get_type_id(), DuckDBType.geometry)
+
+def test_geometry_crs_none() raises:
+    """A plain GEOMETRY (no CRS) returns None from geometry_type_crs()."""
+    var con = DuckDB.connect(":memory:")
+    var result = con.execute("SELECT CAST('POINT(0 1)' AS GEOMETRY) AS g")
+    assert_false(Bool(result.column_type(0).geometry_type_crs()))
+
+def test_geometry_crs_value() raises:
+    """A GEOMETRY column with a CRS returns the CRS string."""
+    var con = DuckDB.connect(":memory:")
+    _ = con.execute("CREATE TABLE t (g GEOMETRY('OGC:CRS84'))")
+    var result = con.execute("SELECT g FROM t")
+    var crs = result.column_type(0).geometry_type_crs()
+    assert_true(Bool(crs))
+    assert_equal(crs.value(), "OGC:CRS84")
+
+def test_geometry_crs_non_geometry() raises:
+    """geometry_type_crs() returns None for a non-GEOMETRY type."""
+    var bigint = LogicalType(DuckDBType.bigint)
+    assert_false(Bool(bigint.geometry_type_crs()))
 
 def main() raises:
     TestSuite.discover_tests[__functions_in_module()]().run()


### PR DESCRIPTION
Add type support on top of the refreshed bindings:
- DuckDBType.geometry and DuckDBType.variant, with write_to names, so these columns report their type instead of "<<unknown>>".
- LogicalType.geometry_type_crs() -> Optional[String], wrapping duckdb_geometry_type_get_crs (None for non-GEOMETRY / no CRS).

`VARIANT` has no dedicated C API helpers yet (the header's "Variant Helpers" section is an empty placeholder), so this is type recognition only; values are read by casting to VARCHAR/JSON in SQL.

Guard against stale generated bindings slipping into main: a new check-generated-api pixi task regenerates the bindings (against the version matching the installed duckdb) and fails on any diff, run from a dedicated CI job in `test.yml`.