### PR TITLE
Fix benchmark drift

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,12 @@ jobs:
           # $MOJO_TARGET_FLAGS is set at the job level (CI only); empty off-CI.
           pixi run mojo run $MOJO_TARGET_FLAGS example.mojo
 
+      - name: Compile-check benchmarks to guard against API/stdlib drift)
+        if: always()
+        run: |
+          source $HOME/.bash_profile
+          pixi run compile-benchmarks
+
   # Verify the rattler-build recipe still builds and its in-package smoke test
   # passes. Builds recipe.local.yaml (source = working tree) so it tests THIS
   # commit; recipe.yaml pins a fixed SHA and is only used for the actual

--- a/benchmark/math_benchmark.mojo
+++ b/benchmark/math_benchmark.mojo
@@ -18,8 +18,8 @@ from duckdb.scalar_function import ScalarFunction, ScalarFunctionSet, FunctionIn
 from duckdb.logical_type import LogicalType
 from duckdb._libduckdb import *
 from std.sys import simd_width_of
-import std.math
-import std.benchmark
+from std import math
+from std import benchmark
 
 
 # ===--------------------------------------------------------------------===#

--- a/benchmark/reduction_benchmark.mojo
+++ b/benchmark/reduction_benchmark.mojo
@@ -18,7 +18,7 @@ from duckdb import *
 from duckdb.aggregate_function import AggregateFunction, AggregateFunctionInfo
 from duckdb._libduckdb import *
 from std.sys import simd_width_of
-import std.benchmark
+from std import benchmark
 
 
 # ===--------------------------------------------------------------------===#

--- a/benchmark/tpch_benchmark.mojo
+++ b/benchmark/tpch_benchmark.mojo
@@ -21,7 +21,7 @@ from duckdb.scalar_function import ScalarFunction, ScalarFunctionSet, FunctionIn
 from duckdb.logical_type import LogicalType, decimal_type
 from duckdb._libduckdb import *
 from std.sys import simd_width_of
-import std.benchmark
+from std import benchmark
 
 
 # ===--------------------------------------------------------------------===#
@@ -332,8 +332,8 @@ def main() raises:
 
     # Validate Q1 results
     print("  Validating Q1 results match...")
-    var std_result = conn.execute(Q1_STANDARD).fetch_all()
-    var mojo_result = conn.execute(Q1_MOJO).fetch_all()
+    var std_result = conn.execute(Q1_STANDARD).fetchall()
+    var mojo_result = conn.execute(Q1_MOJO).fetchall()
     print("    Standard Q1 rows: " + String(len(std_result)))
     print("    Mojo Q1 rows:     " + String(len(mojo_result)))
 

--- a/benchmark/tpch_benchmark_op_replacement.mojo
+++ b/benchmark/tpch_benchmark_op_replacement.mojo
@@ -19,7 +19,7 @@ from duckdb import *
 from duckdb.api import DuckDB
 from duckdb._libduckdb import *
 from operator_replacement import OperatorReplacementLib
-import std.benchmark
+from std import benchmark
 
 
 # ===--------------------------------------------------------------------===#
@@ -37,7 +37,7 @@ comptime SIMD_WIDTH = 8
 # For add/sub the raw integers share the same scale, so we just add/sub.
 # For multiply we need scale correction: (scale4 × scale4) / 10000 → scale4.
 
-def mojo_add(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector):
+def mojo_add(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector) abi("C"):
     """SIMD addition on scaled Int64 DECIMAL values."""
     ref lib = DuckDB().libduckdb()
     var size = lib.duckdb_data_chunk_get_size(input)
@@ -59,7 +59,7 @@ def mojo_add(info: duckdb_function_info, input: duckdb_data_chunk, output: duckd
         result_data[i] = a_data[i] + b_data[i]
 
 
-def mojo_subtract(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector):
+def mojo_subtract(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector) abi("C"):
     """SIMD subtraction on scaled Int64 DECIMAL values."""
     ref lib = DuckDB().libduckdb()
     var size = lib.duckdb_data_chunk_get_size(input)
@@ -81,7 +81,7 @@ def mojo_subtract(info: duckdb_function_info, input: duckdb_data_chunk, output: 
         result_data[i] = a_data[i] - b_data[i]
 
 
-def mojo_multiply(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector):
+def mojo_multiply(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector) abi("C"):
     """SIMD multiplication on scaled Int64 DECIMAL values.
 
     Both inputs are DECIMAL(18,4) — scale 4 each. Raw multiply gives scale 8.
@@ -109,7 +109,7 @@ def mojo_multiply(info: duckdb_function_info, input: duckdb_data_chunk, output: 
         result_data[i] = a_data[i] * b_data[i] // 10000
 
 
-def mojo_divide(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector):
+def mojo_divide(info: duckdb_function_info, input: duckdb_data_chunk, output: duckdb_vector) abi("C"):
     """SIMD division (DOUBLE) — DuckDB uses DOUBLE for DECIMAL division too."""
     ref lib = DuckDB().libduckdb()
     var size = lib.duckdb_data_chunk_get_size(input)
@@ -136,7 +136,7 @@ def mojo_divide(info: duckdb_function_info, input: duckdb_data_chunk, output: du
 # ===--------------------------------------------------------------------===#
 
 def register_decimal_op[
-    func: def(duckdb_function_info, duckdb_data_chunk, duckdb_vector) -> None
+    func: def(duckdb_function_info, duckdb_data_chunk, duckdb_vector) thin abi("C") -> None
 ](name: String, conn: duckdb_connection) raises:
     """Register a binary operator function as (DECIMAL(18,4), DECIMAL(18,4)) -> DECIMAL(18,4)."""
     ref lib = DuckDB().libduckdb()
@@ -160,7 +160,7 @@ def register_decimal_op[
 
 
 def register_double_op[
-    func: def(duckdb_function_info, duckdb_data_chunk, duckdb_vector) -> None
+    func: def(duckdb_function_info, duckdb_data_chunk, duckdb_vector) thin abi("C") -> None
 ](name: String, conn: duckdb_connection) raises:
     """Register a binary operator function as (DOUBLE, DOUBLE) -> DOUBLE."""
     ref lib = DuckDB().libduckdb()

--- a/packages/operator-replacement/duckdb_operator_replacement_wrapper.cpp
+++ b/packages/operator-replacement/duckdb_operator_replacement_wrapper.cpp
@@ -23,13 +23,8 @@ void register_operator_replacement(duckdb_connection con) {
     // Version-specific registration:
     // - v1.4.4: Direct push_back to optimizer_extensions vector
     // - v1.5.0+: Use OptimizerExtension::Register() static method
-    
-    // For DuckDB v1.4.4:
-    auto &config = DBConfig::GetConfig(*connection->context);
-    config.optimizer_extensions.push_back(extension);
-    
-    // For DuckDB v1.5.0-dev and later, uncomment this line and comment out the above:
-    // OptimizerExtension::Register(DBConfig::GetConfig(*connection->context), extension);
+    //   (DBConfig::optimizer_extensions is no longer a public member)
+    OptimizerExtension::Register(DBConfig::GetConfig(*connection->context), extension);
 }
 
 }

--- a/packages/operator-replacement/src/operator_replacement.mojo
+++ b/packages/operator-replacement/src/operator_replacement.mojo
@@ -1,8 +1,6 @@
 from std.ffi import c_char
 from std.pathlib import Path
-from std.ffi import _find_dylib
-from std.ffi import _Global, OwnedDLHandle
-from std.ffi import _get_dylib_function as _ffi_get_dylib_function
+from std.ffi import _find_dylib, _Global, OwnedDLHandle
 
 # ===-----------------------------------------------------------------------===#
 # FFI definitions for the DuckDB Operator Replacement C API.
@@ -25,33 +23,24 @@ comptime OPERATOR_REPLACEMENT_LIBRARY = _Global["OPERATOR_REPLACEMENT_LIBRARY", 
 def _init_dylib() -> OwnedDLHandle:
     return _find_dylib["libduckdb_operator_replacement"](materialize[OPERATOR_REPLACEMENT_PATHS]())
 
-@always_inline
-def _get_dylib_function[
-    func_name: StaticString, result_type: __TypeOfAllTypes
-]() raises -> result_type:
-    return _ffi_get_dylib_function[
-        OPERATOR_REPLACEMENT_LIBRARY(),
-        func_name,
-        result_type,
-    ]()
-
-struct _dylib_function[fn_name: StaticString, type: __TypeOfAllTypes](TrivialRegisterPassable):
+struct _dylib_function[fn_name: StaticString, type: TrivialRegisterPassable](TrivialRegisterPassable):
     comptime fn_type = Self.type
 
     @staticmethod
     def load() raises -> Self.type:
-        return _get_dylib_function[Self.fn_name, Self.type]()
+        return OPERATOR_REPLACEMENT_LIBRARY.get_or_create_ptr()[]
+            .borrow()._get_function[Self.fn_name, Self.type]()
 
 # ===--------------------------------------------------------------------===#
 # Function bindings
 # ===--------------------------------------------------------------------===#
 
 comptime _register_function_replacement = _dylib_function["register_function_replacement",
-    def(UnsafePointer[c_char, ImmutAnyOrigin], UnsafePointer[c_char, ImmutAnyOrigin]) -> NoneType
+    def(UnsafePointer[c_char, ImmutAnyOrigin], UnsafePointer[c_char, ImmutAnyOrigin]) thin abi("C") -> NoneType
 ]
 
 comptime _register_operator_replacement = _dylib_function["register_operator_replacement",
-    def(UnsafePointer[NoneType, MutAnyOrigin]) -> NoneType
+    def(UnsafePointer[NoneType, MutAnyOrigin]) thin abi("C") -> NoneType
 ]
 
 # ===--------------------------------------------------------------------===#

--- a/pixi.toml
+++ b/pixi.toml
@@ -51,6 +51,11 @@ test-extension = { cmd = "bash -c 'mojo run $MOJO_TARGET_FLAGS test-extension/te
 
 test = {depends-on = ["test-library", "test-demo-extension", "test-extension"]}
 
+# Compile-check (no run) the benchmarks so they can't silently rot when the
+# stdlib or duckdb API drifts. The op-replacement benchmark needs the `full`
+# environment and is excluded here (see scripts/compile_check.sh).
+compile-benchmarks = { cmd = "bash scripts/compile_check.sh benchmark", depends-on = ["build"] }
+
 # for local development
 [dependencies]
 libduckdb-devel = "=1.5.3"
@@ -69,6 +74,13 @@ MODULAR_MOJO_MAX_IMPORT_PATH = "$PIXI_PROJECT_ROOT,$CONDA_PREFIX/lib/mojo"
 duckdb-from-source = { path = "packages/duckdb-from-source" }
 duckdb-operator-replacement = { path = "packages/operator-replacement" }
 mojo = "=1.0.0b2.dev2026060206"
+
+# The `full` environment sets no-default-feature = true, so the top-level
+# [activation.env] above does not apply. Re-declare the import path here so
+# `mojo` finds both the `duckdb` package (project root) and the installed
+# packages — stdlib + operator_replacement — under $CONDA_PREFIX/lib/mojo.
+[feature.operator-replacement.activation.env]
+MODULAR_MOJO_MAX_IMPORT_PATH = "$PIXI_PROJECT_ROOT,$CONDA_PREFIX/lib/mojo"
 
 # Environments
 # 

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ path = "duckdb"
 
 [tasks]
 build = "pixi run mojo precompile duckdb -o duckdb.mojoc"
-test-library = { cmd = "bash scripts/run_tests.sh", depends-on = ["build"] }
+test-library = { cmd = "bash scripts/run_tests.sh" }
 clone-duckdb = "sh scripts/clone_duckdb.sh"
 generate-api = { cmd = "python3 scripts/generate_mojo_api.py --duckdb-dir .duckdb-src --output duckdb/_libduckdb.mojo", depends-on = ["clone-duckdb"] }
 # Fails if duckdb/_libduckdb.mojo is out of sync with the DuckDB version
@@ -54,7 +54,7 @@ test = {depends-on = ["test-library", "test-demo-extension", "test-extension"]}
 # Compile-check (no run) the benchmarks so they can't silently rot when the
 # stdlib or duckdb API drifts. The op-replacement benchmark needs the `full`
 # environment and is excluded here (see scripts/compile_check.sh).
-compile-benchmarks = { cmd = "bash scripts/compile_check.sh benchmark", depends-on = ["build"] }
+compile-benchmarks = { cmd = "bash scripts/compile_check.sh benchmark" }
 
 # for local development
 [dependencies]

--- a/scripts/compile_check.sh
+++ b/scripts/compile_check.sh
@@ -8,18 +8,13 @@
 # which is all we want from a guard against API/ABI drift.
 #
 # Usage: scripts/compile_check.sh <dir> [<dir> ...]
-# Runs via `pixi run compile-benchmarks` (see pixi.toml), which builds the
-# duckdb.mojoc package first.
+# Runs via `pixi run compile-benchmarks` (see pixi.toml). Compiles the duckdb
+# package from source per file (see the EXPERIMENT note in run_tests.sh).
 set -e
 
 # Optional Mojo codegen target override, set ONLY in CI — see run_tests.sh and
 # .github/workflows/test.yml for the rationale. Unset locally → native build.
 read -ra MOJO_TARGET <<< "${MOJO_TARGET_FLAGS:-}"
-
-if [ ! -f "./duckdb.mojoc" ]; then
-    echo "ERROR: duckdb.mojoc not found in CWD. Run 'pixi run build' first."
-    exit 1
-fi
 
 # Files that can't be compiled in the default environment. Keep this list short
 # and explain every entry — anything excluded here is NOT guarded against drift.
@@ -39,20 +34,7 @@ is_excluded() {
 }
 
 OUT_DIR="$(mktemp -d)"
-HID_DUCKDB=0
-cleanup() {
-    rm -rf "$OUT_DIR"
-    [[ "$HID_DUCKDB" == "1" ]] && mv duckdb.bak duckdb
-}
-trap cleanup EXIT
-
-# On CI, hide duckdb/ so mojo uses the pre-built package instead of recompiling
-# it from source for every file (saves 9+ GB peak memory) — same trick as
-# run_tests.sh.
-if [[ "${CI:-}" == "true" ]]; then
-    mv duckdb duckdb.bak
-    HID_DUCKDB=1
-fi
+trap 'rm -rf "$OUT_DIR"' EXIT
 
 shopt -s nullglob
 failed=0
@@ -64,7 +46,13 @@ for dir in "$@"; do
             continue
         fi
         echo "--- Compiling: $f ---"
-        if mojo build "${MOJO_TARGET[@]}" "$f" -o "$OUT_DIR/$(basename "$f").bin"; then
+        # --emit object: compile through codegen but skip the executable link.
+        # All the drift we guard against (imports, renamed APIs, ABI signatures)
+        # is caught at compile time, so linking adds nothing and a full link
+        # spuriously fails on linux for math-using files (mojo doesn't put -lm on
+        # the link line: "libm.so.6: DSO missing from command line"). Skipping
+        # the link sidesteps that and is faster.
+        if mojo build --emit object "${MOJO_TARGET[@]}" "$f" -o "$OUT_DIR/$(basename "$f").o"; then
             checked=$((checked + 1))
         else
             echo "ERROR: failed to compile $f"

--- a/scripts/compile_check.sh
+++ b/scripts/compile_check.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Compile-check every Mojo file in a directory without running it.
+#
+# Benchmarks and examples aren't part of the test suite, so they silently rot
+# when the Mojo stdlib or the duckdb API changes (renamed methods, new ABI
+# requirements on callbacks, stdlib import-path churn). A plain `mojo build`
+# catches all of those in seconds — no data generation, no runtime variance —
+# which is all we want from a guard against API/ABI drift.
+#
+# Usage: scripts/compile_check.sh <dir> [<dir> ...]
+# Runs via `pixi run compile-benchmarks` (see pixi.toml), which builds the
+# duckdb.mojoc package first.
+set -e
+
+# Optional Mojo codegen target override, set ONLY in CI — see run_tests.sh and
+# .github/workflows/test.yml for the rationale. Unset locally → native build.
+read -ra MOJO_TARGET <<< "${MOJO_TARGET_FLAGS:-}"
+
+if [ ! -f "./duckdb.mojoc" ]; then
+    echo "ERROR: duckdb.mojoc not found in CWD. Run 'pixi run build' first."
+    exit 1
+fi
+
+# Files that can't be compiled in the default environment. Keep this list short
+# and explain every entry — anything excluded here is NOT guarded against drift.
+EXCLUDE=(
+    # Requires the `full` environment (duckdb-from-source + the
+    # operator_replacement package). Covered separately; see the full-env CI
+    # job rather than this default-env check.
+    "benchmark/tpch_benchmark_op_replacement.mojo"
+)
+
+is_excluded() {
+    local f="$1"
+    for e in "${EXCLUDE[@]}"; do
+        [[ "$f" == "$e" ]] && return 0
+    done
+    return 1
+}
+
+OUT_DIR="$(mktemp -d)"
+HID_DUCKDB=0
+cleanup() {
+    rm -rf "$OUT_DIR"
+    [[ "$HID_DUCKDB" == "1" ]] && mv duckdb.bak duckdb
+}
+trap cleanup EXIT
+
+# On CI, hide duckdb/ so mojo uses the pre-built package instead of recompiling
+# it from source for every file (saves 9+ GB peak memory) — same trick as
+# run_tests.sh.
+if [[ "${CI:-}" == "true" ]]; then
+    mv duckdb duckdb.bak
+    HID_DUCKDB=1
+fi
+
+shopt -s nullglob
+failed=0
+checked=0
+for dir in "$@"; do
+    for f in "$dir"/*.mojo; do
+        if is_excluded "$f"; then
+            echo "--- Skipping (needs full env): $f ---"
+            continue
+        fi
+        echo "--- Compiling: $f ---"
+        if mojo build "${MOJO_TARGET[@]}" "$f" -o "$OUT_DIR/$(basename "$f").bin"; then
+            checked=$((checked + 1))
+        else
+            echo "ERROR: failed to compile $f"
+            failed=$((failed + 1))
+        fi
+    done
+done
+
+echo
+if [[ "$failed" -gt 0 ]]; then
+    echo "Compile-check FAILED: $failed file(s) did not compile ($checked passed)."
+    exit 1
+fi
+echo "Compile-check passed: $checked file(s) compiled."

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Run tests against the pre-built duckdb.mojoc (created by the build task).
-# The package must exist in CWD before this script runs.
+# Run tests, compiling the duckdb package from source for each test file.
+#
 set -e
 
 # Optional Mojo codegen target override. Set ONLY in CI (see
@@ -8,18 +8,6 @@ set -e
 # 9V74 runners, where host-CPU codegen emits AVX-512 that Azure has masked,
 # causing SIGILL. Unset locally → no override, so local builds stay native.
 read -ra MOJO_TARGET <<< "${MOJO_TARGET_FLAGS:-}"
-
-if [ ! -f "./duckdb.mojoc" ]; then
-    echo "ERROR: duckdb.mojoc not found in CWD. Run 'pixi run build' first."
-    exit 1
-fi
-
-# On CI, hide duckdb/ so mojo uses the pre-built package instead of recompiling
-# from source for each test file (saves 9+ GB peak memory).
-if [[ "${CI:-}" == "true" ]]; then
-    mv duckdb duckdb.bak
-    trap "mv duckdb.bak duckdb" EXIT
-fi
 
 # Tests that compile quickly (no heavy generic monomorphization)
 TESTS=(


### PR DESCRIPTION
Fixes the `benchmark/` modules (which had silently rotted behind Mojo/library updates), adds a CI guard so they can't rot again, and removes the now-unnecessary duckdb prebuild machinery from the test/compile-check path.

## Benchmark fixes

The benchmarks no longer compiled

- **Stdlib imports**: `import std.{math,benchmark}` binds the dotted path, but the code used the bare names. Switched to `from std import {math,benchmark}` (the convention already used in `test/`). All four benchmarks.
- **`tpch_benchmark`**: `Result.fetch_all()` was renamed to `fetchall()`.
- **operator-replacement** (`full` env only):
  - C++ wrapper: DuckDB 1.5 removed the public `DBConfig::optimizer_extensions` member → use `OptimizerExtension::Register()`.
  - `operator_replacement.mojo`: `__TypeOfAllTypes` → `TrivialRegisterPassable`; dropped the removed `_get_dylib_function` helper for the current `LIBRARY.get_or_create_ptr()[].borrow()._get_function[...]()` pattern; function-pointer types now `thin abi("C")`.
  - `tpch_benchmark_op_replacement`: DuckDB C API callbacks now require `abi("C")`.
  - `pixi.toml`: the `full` env uses `no-default-feature = true`, so the top-level `[activation.env]` didn't apply — added a matching `[feature.operator-replacement.activation.env]` so mojo finds the `duckdb` package.

## Drift guard

New `scripts/compile_check.sh` + `compile-benchmarks` pixi task, wired into the CI build job. Compile-checks every benchmark with `mojo build --emit object` (codegen, no executable link) catches import/API/ABI drift without running the benchmarks.

## Build from source

`run_tests.sh`/`compile_check.sh` previously required a pre-built `duckdb.mojoc` and, on CI, hid `duckdb/` (`mv duckdb duckdb.bak`) so mojo used the prebuilt package instead of recompiling from source per file as a workaround for an older compiler's OOM issue

> Note: a cold compilation cache (after a Mojo bump or `pixi.lock` change) recompiles duckdb per file and is slower than warm-cache numbers but still within memory limits.
